### PR TITLE
support alternative "placemark" schema

### DIFF
--- a/app/blitz-server.ts
+++ b/app/blitz-server.ts
@@ -45,6 +45,7 @@ export const { gSSP, gSP, api } = setupBlitzServer({
           res.end();
           return;
         }
+        console.log("500 middleware failure: ", e);
         res.statusCode = 500;
         res.send({ error: "Internal error" });
         res.end();

--- a/db/schema.prisma
+++ b/db/schema.prisma
@@ -1,6 +1,7 @@
 datasource db {
   provider = "postgres"
   url      = env("DATABASE_URL")
+  shadowDatabaseUrl = env("SHADOW_DATABASE_URL")
 }
 
 generator client {

--- a/integrations/pg.ts
+++ b/integrations/pg.ts
@@ -3,4 +3,7 @@ import { env } from "app/lib/env_server";
 
 export const pool = new Pool({
   connectionString: env.DATABASE_URL,
+  ssl: {
+    rejectUnauthorized: false,
+  },
 });

--- a/pages/api/replicache-pull.ts
+++ b/pages/api/replicache-pull.ts
@@ -311,10 +311,10 @@ export async function replicachePullInner(
       rows: [{ cookie }],
     } = await pgClient.query(
       `SELECT MAX(max) as cookie FROM (
-SELECT MAX(version) from "Presence" WHERE "wrappedFeatureCollectionId" = $1
-UNION SELECT MAX(version) from "WrappedFeature" WHERE "wrappedFeatureCollectionId" = $1
-UNION SELECT MAX(version) from "LayerConfig" WHERE "wrappedFeatureCollectionId" = $1
-UNION SELECT MAX(version) from "Folder" WHERE "wrappedFeatureCollectionId" = $1) as m;
+SELECT MAX(version) from placemark."Presence" WHERE "wrappedFeatureCollectionId" = $1
+UNION SELECT MAX(version) from placemark."WrappedFeature" WHERE "wrappedFeatureCollectionId" = $1
+UNION SELECT MAX(version) from placemark."LayerConfig" WHERE "wrappedFeatureCollectionId" = $1
+UNION SELECT MAX(version) from placemark."Folder" WHERE "wrappedFeatureCollectionId" = $1) as m;
 `,
       [wrappedFeatureCollectionId]
     );

--- a/pages/api/replicache-push.ts
+++ b/pages/api/replicache-push.ts
@@ -77,7 +77,7 @@ export async function replicachePushInner(
     const [targetCollection] = affectedFeatureCollections;
 
     const permission = await client.query(
-      `SELECT id FROM "WrappedFeatureCollection"
+      `SELECT id FROM placemark."WrappedFeatureCollection"
                             WHERE id = $1 AND "organizationId" = $2`,
       [targetCollection, session.orgId]
     );
@@ -90,13 +90,13 @@ export async function replicachePushInner(
     const {
       rows: [{ version }],
     } = await client.query<{ version: number }>(
-      `INSERT INTO "ReplicacheVersionSingleton" (id, version) VALUES (0, 0) ON CONFLICT (id) DO UPDATE SET version = "ReplicacheVersionSingleton".version + 1 RETURNING version;`
+      `INSERT INTO placemark."ReplicacheVersionSingleton" (id, version) VALUES (0, 0) ON CONFLICT (id) DO UPDATE SET version = placemark."ReplicacheVersionSingleton".version + 1 RETURNING version;`
     );
 
     const replicacheClientResult = await client.query<{
       lastMutationId: number;
     }>(
-      `INSERT INTO "ReplicacheClient" (id, "userId", "updatedAt", "lastMutationId") VALUES ($1, $2, NOW(), 0) ON CONFLICT (id) DO UPDATE SET "updatedAt" = EXCLUDED."updatedAt" RETURNING "lastMutationId";`,
+      `INSERT INTO placemark."ReplicacheClient" (id, "userId", "updatedAt", "lastMutationId") VALUES ($1, $2, NOW(), 0) ON CONFLICT (id) DO UPDATE SET "updatedAt" = EXCLUDED."updatedAt" RETURNING "lastMutationId";`,
       [push.clientID, session.userId]
     );
 
@@ -141,7 +141,7 @@ export async function replicachePushInner(
     }
 
     await client.query(
-      `UPDATE "ReplicacheClient" SET "lastMutationId" = $1 WHERE id = $2`,
+      `UPDATE placemark."ReplicacheClient" SET "lastMutationId" = $1 WHERE id = $2`,
       [lastMutationId, push.clientID]
     );
 


### PR DESCRIPTION
fully working PR to be able to use heroku (see `SHADOW_DATABASE_URL`) and the "placemark" schema of an existing database instead of the "public" schema. 

- [ ] Ideally schema would be configurable.

For heroku set `heroku config:set -a YOUR-APPNAME PGSSLMODE=no-verify` so the postgres server does not check the self-signed certificate. The client side is already set to not check the certificate in this branch. https://stackoverflow.com/questions/61097695/self-signed-certificate-error-during-query-the-heroku-hosted-postgres-database#comment117446613_61125814

You still have to fix `default_layers.ts`

Use `psql` and `drop schema placemark cascade; drop schema placemarkshadow cascade;` to reset the database.

If you're using a mini database ($5/mo, 10k rows max, 20 concurrent), ` heroku pg:killall YOUR_DATABASENAME -a YOUR-APPNAME` resets all stale connections. `yarn prisma studio` can be used to set superuser.

![image](https://github.com/thadk/placemark/assets/283343/a070b82c-be74-4bd4-82d2-e354392fe148)

example.env values:
```
DATABASE_URL=postgres://un:pw@host:port/dbname?schema=placemark&connection_limit=3
SHADOW_DATABASE_URL=postgres://un:pw@host:port/dbname?schema=placemarkshadow&connection_limit=2
```
